### PR TITLE
Update Railway deploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ tags:
 
 This repository contains a Discord bot for the Z3D community using [discord.js](https://discord.js.org/) with ticket and reaction role functionality.
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/PxM3nl)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new)
+Use Railway's "Deploy from GitHub" option to deploy this repository. Railway will
+prompt you for required environment variables such as `DISCORD_TOKEN` when you
+deploy.
 
 ## ✨ Features
 
@@ -26,7 +29,8 @@ This repository contains a Discord bot for the Z3D community using [discord.js](
 
 - Set the `DISCORD_TOKEN` environment variable (Railway prompts for it on deploy)
 
-- Start the bot using `node index.js`
+- Start the bot using `node index.js` (you'll be prompted for the token if the
+  environment variable is unset)
 - Optional admin UI: `npm run admin` then visit <http://localhost:3000/admin>
 
 ## 📝 Notes

--- a/index.js
+++ b/index.js
@@ -89,4 +89,15 @@ client.on('messageReactionRemove', async (reaction, user) => {
   if (member) member.roles.remove(roleId).catch(console.error);
 });
 
-client.login(process.env.DISCORD_TOKEN);
+async function start() {
+  let token = process.env.DISCORD_TOKEN;
+  if (!token) {
+    const readline = require('readline');
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    token = await new Promise(resolve => rl.question('Enter your Discord bot token: ', resolve));
+    rl.close();
+  }
+  client.login(token);
+}
+
+start();


### PR DESCRIPTION
## Summary
- update README instructions to clarify Railway deployment and token prompts
- prompt for DISCORD_TOKEN at runtime if it's not set

## Testing
- `npm test` *(fails: Missing script)*
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_6850e110e20c83288ae1bff2fcf8fedd