### PR TITLE
Restrict reaction role setup command to admins

### DIFF
--- a/commands/setup-reaction-roles.js
+++ b/commands/setup-reaction-roles.js
@@ -1,11 +1,12 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
 const fs = require('fs');
 const config = require('../config.json');
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('setup-reaction-roles')
-    .setDescription('Post a reaction role message and record its ID'),
+    .setDescription('Post a reaction role message and record its ID')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
   async execute(interaction) {
     const rr = config.reactionRoles;
     if (!rr || !rr.emojiRoleMap || Object.keys(rr.emojiRoleMap).length === 0) {


### PR DESCRIPTION
## Summary
- ensure `/setup-reaction-roles` is admin only by setting default permissions

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68513a0f129883289ee820d034a2cdfe