### PR TITLE
Add config reload note and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ This repository contains a Discord bot for the Z3D community using [discord.js](
 - Start the bot using `node index.js`
 - Optional admin UI: `npm run admin` then visit <http://localhost:3000/admin>
 
+If you change settings through the admin interface, restart the bot so it reloads
+the updated configuration. Alternatively, use the provided reload function in
+`utils.js` to reread `config.json` without a full restart.
+
 ## 📝 Notes
 
 This is a basic bot with the prefix `!`, more information can be founded at their [offical documentation](https://discordpy.readthedocs.io/en/stable/api.html).

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,14 @@
 // Utility functions for permission checks and logging
 const { PermissionsBitField } = require('discord.js');
 const fs = require('fs');
+const path = require('path');
+
+// Reload config.json from disk
+function reloadConfig() {
+  const configPath = path.join(__dirname, 'config.json');
+  delete require.cache[require.resolve(configPath)];
+  return require(configPath);
+}
 
 module.exports = {
   hasSupportRole(member, supportRoleId) {
@@ -10,5 +18,6 @@ module.exports = {
     // Optionally extend for file logging
     // For now, just a stub for channel logging
     return `[${type}] ${user.tag} in #${channel.name}`;
-  }
+  },
+  reloadConfig
 };


### PR DESCRIPTION
## Summary
- mention restarting after using admin interface in README
- add simple `reloadConfig` helper

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850c875eb4c8328aafaa751ec1839b9