### PR TITLE
Add basic authentication to admin interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This repository contains a Discord bot for the Z3D community using [discord.js](
 - Install packages using `npm install`
 - Start the bot using `node index.js`
 - Optional admin UI: `npm run admin` then visit <http://localhost:3000/admin>
+  - Set `ADMIN_PASSWORD` in your environment to enable a basic auth prompt when
+    accessing the admin interface.
 
 ## 📝 Notes
 


### PR DESCRIPTION
## Summary
- add simple HTTP basic authentication middleware
- guard `/admin`, `/admin/credentials`, and `/admin/reaction-roles`
- document `ADMIN_PASSWORD` setup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850c85fb93c83288e9465428a785ef0